### PR TITLE
Templatize and Render jOOQ XML configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+.idea/

--- a/README.md
+++ b/README.md
@@ -61,7 +61,22 @@ The plugin exposes several settings:
 
             jooqConfigFile := Some(new java.io.File("/path/to/your/file")
 
-   This will override the `jooq-options` setting if present. 
+   This will override the `jooq-options` setting if present. This file now allows for users to pass templatable values using the Java Minimal Template Engine. Refer to <https://code.google.com/p/jmte/> for a complete description of how to use JMTE. 
+   
+* *jooq-config-template-values*: an `Option[()=>Map[String, AnyRef]]` that allows you to supply a specify a map of string keys and corresponding values to be sustituted into a specified jooqConfigFile. Set it like this:
+
+```scala
+jooqConfigTemplateValues := Some(() => {
+  val envFile = baseDirectory.value / ".env"
+  if (envFile.isFile){
+    IO.load(System.getProperties, envFile)
+  }
+
+  val conf = ConfigFactory.parseFile(new File("conf/development.conf")).resolve()
+
+  JavaConversions.mapAsScalaMap(conf.getObject("db.default").unwrapped()).toMap
+})
+```
 
 * *jooq-output-directory* (`jooqOutputDirectory` in build.sbt): a `File`
   indicating where JOOQ should deposit the source files it generates. By

--- a/build.sbt
+++ b/build.sbt
@@ -8,3 +8,4 @@ name := "jooq-sbt-plugin"
 
 crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.4")
 
+libraryDependencies += "com.floreysoft" % "jmte" % "3.2.0"

--- a/src/main/scala/sean8223/JOOQPlugin.scala
+++ b/src/main/scala/sean8223/JOOQPlugin.scala
@@ -72,6 +72,8 @@ object JOOQPlugin extends Plugin {
     jooqOutputDirectory <<= (sourceManaged in Compile)( _ / "java"),
 
     jooqConfigFile := None,
+
+    jooqConfigTemplateValues := None,
     
     sourceGenerators in Compile <+= (streams, 
 				     baseDirectory, 
@@ -95,7 +97,6 @@ object JOOQPlugin extends Plugin {
 	    "org.slf4j" % "slf4j-api" % "1.7.2" % JOOQ.name,
 	    "org.slf4j" % "slf4j-log4j12" % "1.7.2" % JOOQ.name,
 	    "org.slf4j" % "jul-to-slf4j" % "1.7.2" % JOOQ.name,
-//      "triplec1988" % "jooq-custom-codegen" % "1.1.0" % JOOQ.name,
 	    "log4j" % "log4j" % "1.2.17" % JOOQ.name)
       }
     },


### PR DESCRIPTION
Harry's used the jooq-sbt-plugin before to great effect. In our recent project, however, we are using jOOQ slightly differently more custom way that before. As a result we were unable to make use of the jooq-sbt-plugin in its current form. The changes made in this fork address two key issues:
- Templatize our jOOQ XML config such that user/environment specific values do not need to be hardcoded and can therefore be checked in to the appropriate repository.
- Allow dependencies from the parent project to be pulled into the classpath to allow more customization with the jOOQ XML config like custom naming strategies and forced types.

To achieve these we have made changes to the following files:
- build.sbt
- ../JOOQPlugin.scala
- README.md
#### Build.sbt

We have added a lightweight templating engine JavaMinimalTemplateEngine(https://code.google.com/p/jmte/). This lightweight library allows for simple templating via “${_variable_}” substitution.
#### JOOQPlugin.scala

The first change made was to add a settingKey to pass in the variables to be substituted. Subsequent changes check to see if both a config file AND config vars have been set before attempting to render the config XML as a temp file and use that for code generation.

The second important change that was made regards classpaths. This change allows the plugin to pull in dependencies from the parent project, be they managed through Ivy/Maven or pulled in via git (as we’re doing with some libraries). One may still scope dependencies in the parent project to the “jooq” config.

The final important change we have made it to looks for either “.java” or “.scala” in the output directory as we use jOOQ’s scala code generator.
#### README

We have updated the documentation for the new settingKey we have added in this fork.
